### PR TITLE
Limit content part settings

### DIFF
--- a/Etch.OrchardCore.Gallery.csproj
+++ b/Etch.OrchardCore.Gallery.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>0.3.1-rc2</Version>
+    <Version>0.3.2-rc2</Version>
     <PackageId>Etch.OrchardCore.Gallery</PackageId>
     <Title>Etch Orchard Core Gallery</Title>
     <Authors>Etch</Authors>

--- a/Manifest.cs
+++ b/Manifest.cs
@@ -4,7 +4,7 @@ using OrchardCore.Modules.Manifest;
     Name = "Gallery",
     Author = "Etch UK",
     Website = "https://etchuk.com",
-    Version = "0.3.1"
+    Version = "0.3.2"
 )]
 
 [assembly: Feature(

--- a/Settings/GalleryPartSettingsDriver.cs
+++ b/Settings/GalleryPartSettingsDriver.cs
@@ -1,17 +1,27 @@
-﻿using OrchardCore.ContentManagement.Metadata.Models;
+﻿using Etch.OrchardCore.Gallery.Models;
+using OrchardCore.ContentManagement.Metadata.Models;
 using OrchardCore.ContentTypes.Editors;
 using OrchardCore.DisplayManagement.Views;
+using System;
 using System.Threading.Tasks;
 
 namespace Etch.OrchardCore.Gallery.Settings
 {
     public class GalleryPartSettingsDriver : ContentTypePartDefinitionDisplayDriver
     {
-        public override IDisplayResult Edit(ContentTypePartDefinition partDefinition)
+        public override IDisplayResult Edit(ContentTypePartDefinition contentTypePartDefinition)
         {
+            if (!string.Equals(nameof(GalleryPart), contentTypePartDefinition.PartDefinition.Name, StringComparison.Ordinal))
+            {
+                return null;
+            }
+
             return Initialize<GalleryPartSettings>("GalleryPartSettings_Edit", model =>
             {
-                partDefinition.PopulateSettings(model);
+                var settings = contentTypePartDefinition.GetSettings<GalleryPartSettings>();
+
+                model.ThumbnailHeight = settings.ThumbnailHeight;
+                model.ThumbnailWidth = settings.ThumbnailWidth;
             })
            .Location("Content");
         }
@@ -20,12 +30,12 @@ namespace Etch.OrchardCore.Gallery.Settings
         {
             var settings = new GalleryPartSettings();
 
-            if (await context.Updater.TryUpdateModelAsync(settings, Prefix, m => m.ThumbnailWidth))
+            if (await context.Updater.TryUpdateModelAsync(settings, Prefix))
             {
                 context.Builder.WithSettings(settings);
             }
 
-            return Edit(contentTypePartDefinition, context.Updater);
+            return Edit(contentTypePartDefinition);
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "etch-orchard-core-gallery",
-    "version": "0.3.1",
+    "version": "0.3.2",
     "description": "[Orchard Core](https://github.com/OrchardCMS/OrchardCore) module for displaying a collection of images & videos.",
     "main": "index.js",
     "author": "Etch",


### PR DESCRIPTION
Noticed the gallery part settings shape was displaying when viewing settings for other parts. Fixed by adding a check in the settings display driver to ensure it's the gallery part whose settings are being modified.

/cc @Newnab 