### PR TITLE
Replace default widget view with a less opinionated default

### DIFF
--- a/Views/Widget-Gallery.cshtml
+++ b/Views/Widget-Gallery.cshtml
@@ -1,6 +1,0 @@
-﻿<section class="section">
-    <div class="section__content">
-        @await DisplayAsync(Model.Header)
-        @await DisplayAsync(Model.Content)
-    </div>
-</section>

--- a/Views/Widget-Gallery.liquid
+++ b/Views/Widget-Gallery.liquid
@@ -1,0 +1,1 @@
+{{ Model.Content | shape_render }}


### PR DESCRIPTION
The new one doesn't output the heading by default and doesn't create nested sections if you use galleries inside sections.

Solves https://github.com/EtchUK/Etch.OrchardCore.Gallery/issues/26